### PR TITLE
Feat/add title page

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,24 @@
+<!-- omit in toc -->
 # slidev-esp-template
 
 This project is a template for [Slidev](https://github.com/slidevjs/slidev) presentations recommended for use at [Espressif](https://www.espressif.com/).
+
+You can jump to:
+
+- [History](#history)
+- [Installation and configuration](#installation-and-configuration)
+  - [Software dependencies](#software-dependencies)
+  - [Template setup](#template-setup)
+- [Usage](#usage)
+- [Learn more about Slidev](#learn-more-about-slidev)
+  - [Quick tips](#quick-tips)
+- [Layout and appearance](#layout-and-appearance)
+  - [Visual layout settings](#visual-layout-settings)
+  - [Update logo](#update-logo)
+- [Slide syncing](#slide-syncing)
+  - [Troubleshooting](#troubleshooting)
+
+## History
 
 The template is based on the Slidev [Getting Started](https://sli.dev/guide/) project with the following changes:
 
@@ -9,9 +27,10 @@ The template is based on the Slidev [Getting Started](https://sli.dev/guide/) pr
   - [slidev-addon-sync](https://github.com/Smile-SA/slidev-addon-sync) -- for usage instructions, see [Slide syncing](#slide-syncing)
   - [Poll and Quiz](https://github.com/Smile-SA/slidev-component-poll) -- see a usage example in [slides.md](./slides.md#poll-and-quiz-added-in-slidev-esp-template) > *Poll and Quiz*.
 - **Layout**: Espressif logo added.
-- **Slide content**: changed or added guidelines in
-  - *Themes*
-  - *Poll and Quiz*
+- **Slide content**:
+  - Replaced Slidev Getting Started title page with a usual Espressif title page
+  - Changed guidelines in *Themes*
+  - Added a slide *Poll and Quiz* describing this plugin
 
 
 ## Installation and configuration
@@ -71,6 +90,10 @@ To start the slide show:
 
 Edit the [slides.md](./slides.md) to see the changes.
 
+Examples of Espressif presentations using Slidev:
+
+- [DevCon23 - Developing, Publishing, and Maintaining Components for ESP-IDF](https://www.youtube.com/watch?v=D86gQ4knUnc)
+
 ## Learn more about Slidev
 
 To get started, see:
@@ -83,6 +106,7 @@ This is part of extensive Slidev [documentation](https://sli.dev/).
 
 ### Quick tips
 
+- If you use VS Code, you can install [Slidev for VS Code](https://sli.dev/features/vscode-extension.html) extension to improve your experience using Slidev.
 - **Include static files**: If you have static files, such as images or diagrams, place them in the `public/` folder. You can then reference them using `src="/image.png"`. For example, to include the image `public/myimage.jpeg` on your slide, use `src="/myimage.png"`.
 - **Embed external code blocks**: If you need to include code blocks, place files containing code in the `snippets/` folder. Then:
   - Mark the regions to include:
@@ -110,7 +134,7 @@ This is part of extensive Slidev [documentation](https://sli.dev/).
   ```
   The parameter `hide` conveniently helps to show or hide the included slides.
 
-## Appearance
+## Layout and appearance
 
 ### Visual layout settings
 

--- a/README.md
+++ b/README.md
@@ -138,6 +138,7 @@ This is part of extensive Slidev [documentation](https://sli.dev/).
 
 ### Visual layout settings
 
+- **Page numbers**: To add page numbers, open the [global-bottom.vue](./global-bottom.vue) file and uncomment its contents.
 - **Color scheme**: To change the color scheme, in the `slides.md` YAML frontmatter, update the parameter `colorSchema`. The default value is `light`, but you can update it to `auto` or `dark`.
 - **Aspect ratio and canvas size**: To change the configuration, in the `slides.md` YAML frontmatter, update the values of `aspectRatio` and `canvasWidth`.
 

--- a/global-bottom.vue
+++ b/global-bottom.vue
@@ -1,0 +1,10 @@
+<!--
+ <template>
+  <footer
+    v-if="$nav.currentLayout !== 'cover'"
+    class="absolute bottom-0 left-0 right-0 p-2 pr-4 text-right"
+  >
+    {{ $nav.currentPage }} / {{ $nav.total }}
+  </footer>
+</template>
+ -->

--- a/global-top.vue
+++ b/global-top.vue
@@ -1,5 +1,5 @@
 <template>
-  <footer
+  <header
     style="
       position: fixed;
       top: 1rem;
@@ -11,5 +11,5 @@
     "
   >
     <img src="/espressif-logos/Espressif_Standard_Logo_EN_Horizontal_Black.svg" alt="Espressif Logo" style="width: 100%;" />
-  </footer>
+  </header>
 </template>

--- a/slides.md
+++ b/slides.md
@@ -3,7 +3,7 @@
 theme: default
 # random image from a curated Unsplash collection by Anthony
 # like them? see https://unsplash.com/collections/94734566/slidev
-background: https://cover.sli.dev
+# background: https://cover.sli.dev
 # favicon, can be a local file path or URL
 favicon: '/favicons/favicon-32x32.png'
 # force color schema for the slides, can be 'auto', 'light', or 'dark'
@@ -13,7 +13,7 @@ aspectRatio: 16/9
 # real width of the canvas, unit in px
 canvasWidth: 980
 # some information about your slides (markdown enabled)
-title: Welcome to Slidev
+title: Espressif
 info: |
   ## Slidev Starter Template
   Presentation slides for developers.
@@ -36,26 +36,19 @@ pollSettings:
   anonymous: true
 ---
 
-# Welcome to Slidev
+# Talk title goes here
 
-Presentation slides for developers
+<span style="font-size: 2rem;">Optional subtitle</span>
 
-<div @click="$slidev.nav.next" class="mt-12 py-1" hover:bg="white op-10">
-  Press Space for next page <carbon:arrow-right />
-</div>
-
-<div class="abs-br m-6 text-xl">
-  <button @click="$slidev.nav.openInEditor()" title="Open in Editor" class="slidev-icon-btn">
-    <carbon:edit />
-  </button>
-  <a href="https://github.com/slidevjs/slidev" target="_blank" class="slidev-icon-btn">
-    <carbon:logo-github />
-  </a>
+<div style="position: absolute; bottom: 2rem; left: 0; width: 100%; text-align: center;">
+  Your name<br>
+  <span style="font-size: 0.8rem; display: inline-block;">YYYY-MM-DD</span>
 </div>
 
 <!--
 The last comment block of each slide will be treated as slide notes. It will be visible and editable in Presenter Mode along with the slide. [Read more in the docs](https://sli.dev/guide/syntax.html#notes)
 -->
+
 
 ---
 transition: fade-out


### PR DESCRIPTION
This PR has the following changes:

- Added a title page that can be easily customized for Espressif presentations
- Added TOC to the README and an example of an existing Slidev presentation
- Added the option to include page numbers on slides

Other examples of Espressif presentations (not using Slidev) can be found here:

- [Espressif DevCon23 Talks](https://www.youtube.com/playlist?list=PLOzvoM7_KnrdTE57M2Gu7JzNenzy9rGIV)
- [Espressif DevCon24](https://www.youtube.com/playlist?list=PLOzvoM7_KnrdtDvNgN6b-GQ-kLppmNxab)
